### PR TITLE
feat:  Add TextArea, Select, SearchInput, and Link Components with Tests

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -10,6 +10,14 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    backgrounds: {
+      default: 'gray-lighter',
+      values: [
+        { name: 'gray-lighter', value: '#e3e3e3' },
+        { name: 'white', value: '#ffffff' },
+        { name: 'dark', value: '#1c1c1e' },
+      ],
+    },
   },
 };
 

--- a/src/components/atoms/Button/Button.stories.tsx
+++ b/src/components/atoms/Button/Button.stories.tsx
@@ -1,69 +1,43 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { Button } from './index';
+import { Button } from ".";
+import { Bookmark, ArrowLeft } from "react-feather"; // Use any icon library
 
-const meta: Meta<typeof Button> = {
-  title: 'Atoms/Button',
-  component: Button,
+export default {
+  title: "Atoms/Button",
   parameters: {
-    layout: 'centered',
+    layout: "centered",
   },
-  tags: ['autodocs'],
-  argTypes: {
-    variant: {
-      control: { type: 'select' },
-      options: ['primary', 'secondary', 'outline'],
-    },
-    size: {
-      control: { type: 'select' },
-      options: ['sm', 'md', 'lg'],
-    },
-    disabled: {
-      control: 'boolean',
-    },
-  },
+  tags: ["autodocs"],
+  component: Button,
 };
 
-export default meta;
-type Story = StoryObj<typeof meta>;
+export const Primary = () => <Button variant="primary">submit</Button>;
 
-export const Primary: Story = {
-  args: {
-    children: 'Button',
-    variant: 'primary',
-  },
-};
+export const Secondary = () => (
+  <Button variant="secondary" iconLeft={<Bookmark size={16} />}>
+    chip
+  </Button>
+);
 
-export const Secondary: Story = {
-  args: {
-    children: 'Button',
-    variant: 'secondary',
-  },
-};
+export const White = () => (
+  <Button variant="white" iconLeft={<ArrowLeft size={16} />}>
+    back
+  </Button>
+);
 
-export const Outline: Story = {
-  args: {
-    children: 'Button',
-    variant: 'outline',
-  },
-};
+export const Inverted = () => (
+  <Button variant="inverted" iconLeft={<Bookmark size={16} />}>
+    chip
+  </Button>
+);
 
-export const Small: Story = {
-  args: {
-    children: 'Small Button',
-    size: 'sm',
-  },
-};
+export const Muted = () => (
+  <Button variant="muted" iconLeft={<Bookmark size={16} />} disabled>
+    chip
+  </Button>
+);
 
-export const Large: Story = {
-  args: {
-    children: 'Large Button',
-    size: 'lg',
-  },
-};
-
-export const Disabled: Story = {
-  args: {
-    children: 'Disabled Button',
-    disabled: true,
-  },
-};
+export const WithRightIcon = () => (
+  <Button variant="primary" iconRight={<Bookmark size={16} />}>
+    Save
+  </Button>
+);

--- a/src/components/atoms/Button/__tests__/Button.test.tsx
+++ b/src/components/atoms/Button/__tests__/Button.test.tsx
@@ -28,7 +28,7 @@ describe("Button", () => {
 
     // Check if the button has the expected classes for secondary variant
     expect(button).toHaveClass(
-      "font-medium rounded-md transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 bg-muted hover:bg-dark text-white px-4 py-2 text-base cursor-pointer"
+      "inline-flex items-center gap-2 rounded-full transition-colors duration-200 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-muted focus-visible:ring-offset-2 bg-dark text-white hover:bg-muted text-body px-4 py-2 cursor-pointer"
     );
   });
 
@@ -38,12 +38,5 @@ describe("Button", () => {
 
     expect(button).toBeDisabled();
     expect(button).toHaveClass("opacity-50");
-  });
-
-  it("renders with different sizes", () => {
-    render(<Button size="lg">Large Button</Button>);
-    const button = screen.getByRole("button");
-
-    expect(button).toHaveClass("text-lg");
   });
 });

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,53 +1,50 @@
+// src/components/ui/Button.tsx
 import React from "react";
+import { combineClassNames } from "../../../utils/combineClassNames";
+import { ButtonProps, ButtonVariant, ButtonSize } from "./types";
 
-export interface ButtonProps {
-  /** Button content */
-  children: React.ReactNode;
-  /** Button variant */
-  variant?: "primary" | "secondary" | "outline";
-  /** Button size */
-  size?: "sm" | "md" | "lg";
-  /** Disabled state */
-  disabled?: boolean;
-  /** Click handler */
-  onClick?: () => void;
-  /** Additional CSS classes */
-  className?: string;
-}
-
-const variantClasses = {
-  primary: "bg-primary hover:bg-white hover:text-primary text-white",
-  secondary: "bg-muted hover:bg-dark text-white",
-  outline:
-    "border-2 border-primary text-primary hover:text-white hover:bg-primary",
+const variantClasses: Record<ButtonVariant, string> = {
+  primary: "bg-primary text-white hover:bg-white hover:text-primary",
+  secondary: "bg-dark text-white hover:bg-muted",
+  white: "bg-white text-dark hover:bg-gray-mid",
+  inverted: "bg-gray-mid text-dark hover:bg-dark hover:text-white",
+  muted: "bg-gray-mid text-muted cursor-not-allowed",
 };
 
-const sizeClasses = {
-  sm: "px-3 py-1.5 text-sm",
-  md: "px-4 py-2 text-base",
-  lg: "px-6 py-3 text-lg",
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: "text-subbody px-3 py-1.5",
+  md: "text-body px-4 py-2",
 };
 
 export const Button: React.FC<ButtonProps> = ({
   children,
   variant = "primary",
   size = "md",
-  disabled = false,
-  onClick,
+  customSize,
+  iconLeft,
+  iconRight,
+  disabled,
   className = "",
+  ...props
 }) => {
-  const baseClasses =
-    "font-medium rounded-md transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2";
-  const disabledClasses = disabled
-    ? "opacity-50 cursor-not-allowed"
-    : "cursor-pointer";
+  const isDisabled = disabled || variant === "muted";
 
-  const classes =
-    `${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${disabledClasses} ${className}`.trim();
+  const baseClasses =
+    "inline-flex items-center gap-2 rounded-full transition-colors duration-200 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-muted focus-visible:ring-offset-2";
+
+  const finalClassName = combineClassNames(
+    baseClasses,
+    variantClasses[variant],
+    customSize || sizeClasses[size],
+    isDisabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
+    className
+  );
 
   return (
-    <button className={classes} onClick={onClick} disabled={disabled}>
-      {children}
+    <button className={finalClassName} disabled={isDisabled} {...props}>
+      {iconLeft && <span className="inline-flex">{iconLeft}</span>}
+      <span>{children}</span>
+      {iconRight && <span className="inline-flex">{iconRight}</span>}
     </button>
   );
 };

--- a/src/components/atoms/Button/types.ts
+++ b/src/components/atoms/Button/types.ts
@@ -1,0 +1,18 @@
+export type ButtonVariant =
+  | "primary"
+  | "secondary"
+  | "white"
+  | "inverted"
+  | "muted";
+export type ButtonSize = "sm" | "md";
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  customSize?: string;
+  iconLeft?: React.ReactNode;
+  iconRight?: React.ReactNode;
+  className?: string;
+}

--- a/src/components/atoms/Icon/types.ts
+++ b/src/components/atoms/Icon/types.ts
@@ -1,7 +1,8 @@
 import React from "react";
+export type Icon = React.ComponentType<React.SVGProps<SVGSVGElement>>;
 export type IconProps = {
   /** Any SVG React component (from react-feather, lucide-react, etc.) */
-  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  icon: Icon;
   size?: number;
   color?: string;
   className?: string;

--- a/src/components/atoms/Link/Link.stories.tsx
+++ b/src/components/atoms/Link/Link.stories.tsx
@@ -1,0 +1,207 @@
+// components/atoms/Link.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { Link } from "./Link";
+import { Icon } from "../Icon";
+import { Link2 } from "react-feather";
+
+const meta = {
+  title: "Atoms/Link",
+  component: Link,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "A flexible and accessible link component with multiple variants, sizes, and states.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    children: {
+      control: "text",
+      description: "Content to display inside the link",
+    },
+    href: {
+      control: "text",
+      description: "The URL or path to link to",
+    },
+    variant: {
+      control: "select",
+      options: ["default", "primary", "secondary", "danger"],
+      description: "Visual variant of the link",
+    },
+    external: {
+      control: "boolean",
+      description: "Whether the link should open in a new tab",
+    },
+    underline: {
+      control: "boolean",
+      description: "Whether to show underline",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Whether the link is disabled",
+    },
+    className: {
+      control: "text",
+      description: "Custom className to extend styles",
+    },
+  },
+  args: {
+    children: "Link Text",
+    href: "#",
+    variant: "default",
+    external: false,
+    underline: true,
+    disabled: false,
+  },
+} satisfies Meta<typeof Link>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Basic Stories
+export const Default: Story = {
+  args: {
+    children: "Default Link",
+    href: "#",
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    children: "Secondary Link",
+    href: "#",
+    variant: "secondary",
+  },
+};
+
+// States
+export const WithoutUnderline: Story = {
+  args: {
+    children: "Link without underline",
+    href: "#",
+    underline: false,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: "Disabled Link",
+    href: "#",
+    disabled: true,
+  },
+};
+
+export const External: Story = {
+  args: {
+    children: "External Link",
+    href: "https://example.com",
+    external: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "External links automatically open in a new tab with proper security attributes.",
+      },
+    },
+  },
+};
+
+// Complex Content
+export const WithComplexContent: Story = {
+  render: () => (
+    <Link href="#" className="inline-flex items-center space-x-2">
+      <Icon icon={Link2} size={18} />
+      <span>Link with icon</span>
+    </Link>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Links can contain complex content including icons and multiple elements.",
+      },
+    },
+  },
+};
+
+// Custom Styling
+export const CustomStyling: Story = {
+  args: {
+    children: "Custom Styled Link",
+    href: "#",
+    className: "font-bold text-purple-600 hover:text-purple-800",
+    underline: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Custom styling can be applied using the className prop.",
+      },
+    },
+  },
+};
+
+// Navigation Examples
+export const NavigationExample: Story = {
+  render: () => (
+    <nav className="space-x-6">
+      <Link href="/" variant="default">
+        Home
+      </Link>
+      <Link href="/about" variant="default">
+        About
+      </Link>
+      <Link href="/services" variant="default">
+        Services
+      </Link>
+    </nav>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Example of using links in a navigation context.",
+      },
+    },
+  },
+};
+
+// Accessibility Demo
+export const AccessibilityDemo: Story = {
+  render: () => (
+    <div className="space-y-4">
+      <p>
+        This is a paragraph with an{" "}
+        <Link href="#" variant="default">
+          inline link
+        </Link>{" "}
+        that demonstrates proper focus states and accessibility.
+      </p>
+      <p>
+        Here's a{" "}
+        <Link href="#" disabled>
+          disabled link
+        </Link>{" "}
+        that cannot be clicked.
+      </p>
+      <p>
+        And here's an{" "}
+        <Link href="https://example.com" external>
+          external link
+        </Link>{" "}
+        that opens in a new tab.
+      </p>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Demonstrates accessibility features including focus states, disabled state, and external link handling.",
+      },
+    },
+  },
+};

--- a/src/components/atoms/Link/Link.tsx
+++ b/src/components/atoms/Link/Link.tsx
@@ -1,0 +1,59 @@
+// components/atoms/Link.tsx
+import { forwardRef } from "react";
+import { LinkProps } from "./types";
+import { combineClassNames } from "../../../utils/combineClassNames";
+
+const variantClasses = {
+  default: "text-dark hover:text-primary visited:text-muted",
+  secondary: "text-primary hover:text-dark visited:text-muted",
+};
+
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  (
+    {
+      href,
+      children,
+      variant = "default",
+      external = false,
+      underline = true,
+      className = "",
+      disabled = false,
+      target,
+      rel,
+      ...props
+    },
+    ref
+  ) => {
+    // Automatically detect external links if not explicitly set
+    const isExternal =
+      external || href.startsWith("http") || href.startsWith("//");
+
+    // Set appropriate target and rel attributes for external links
+    const linkTarget = target || (isExternal ? "_blank" : undefined);
+    const linkRel = rel || (isExternal ? "noopener noreferrer" : undefined);
+
+    const classes = combineClassNames([
+      variantClasses[variant],
+      underline && "underline",
+      disabled && "opacity-50 cursor-not-allowed pointer-events-none",
+      "transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-muted rounded",
+      className,
+    ]);
+
+    return (
+      <a
+        ref={ref}
+        href={disabled ? undefined : href}
+        target={linkTarget}
+        rel={linkRel}
+        className={classes}
+        aria-disabled={disabled}
+        {...props}
+      >
+        {children}
+      </a>
+    );
+  }
+);
+
+Link.displayName = "Link";

--- a/src/components/atoms/Link/__tests__/Link.test.tsx
+++ b/src/components/atoms/Link/__tests__/Link.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { Link } from "../Link";
+
+describe("Link component", () => {
+  it("renders the link with default props", () => {
+    render(<Link href="/home">Home</Link>);
+    const link = screen.getByRole("link", { name: /home/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/home");
+    expect(link).toHaveClass("text-dark");
+    expect(link).toHaveClass("underline");
+  });
+
+  it("applies the secondary variant class", () => {
+    render(
+      <Link href="/about" variant="secondary">
+        About
+      </Link>
+    );
+    const link = screen.getByRole("link", { name: /about/i });
+    expect(link).toHaveClass("text-primary");
+  });
+
+  it("does not underline text when underline is false", () => {
+    render(
+      <Link href="/no-underline" underline={false}>
+        No Underline
+      </Link>
+    );
+    const link = screen.getByRole("link", { name: /no underline/i });
+    expect(link).not.toHaveClass("underline");
+  });
+
+  it("detects and marks external links with target and rel", () => {
+    render(<Link href="https://example.com">External</Link>);
+    const link = screen.getByRole("link", { name: /external/i });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("respects explicitly passed target and rel", () => {
+    render(
+      <Link href="https://example.com" target="_self" rel="nofollow">
+        Custom External
+      </Link>
+    );
+    const link = screen.getByRole("link", { name: /custom external/i });
+    expect(link).toHaveAttribute("target", "_self");
+    expect(link).toHaveAttribute("rel", "nofollow");
+  });
+
+  it("forwards refs correctly", () => {
+    const ref = React.createRef<HTMLAnchorElement>();
+    render(
+      <Link href="/with-ref" ref={ref}>
+        Ref Link
+      </Link>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
+  });
+
+  it("appends custom className", () => {
+    render(
+      <Link href="/custom" className="custom-class">
+        Custom
+      </Link>
+    );
+    const link = screen.getByRole("link", { name: /custom/i });
+    expect(link).toHaveClass("custom-class");
+  });
+});

--- a/src/components/atoms/Link/types.ts
+++ b/src/components/atoms/Link/types.ts
@@ -1,0 +1,17 @@
+export interface LinkProps
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  /** The URL or path to link to */
+  href: string;
+  /** Content to display inside the link */
+  children: React.ReactNode;
+  /** Visual variant of the link */
+  variant?: "default" | "secondary";
+  /** Whether the link should open in a new tab */
+  external?: boolean;
+  /** Whether to show underline */
+  underline?: boolean;
+  /** Custom className to extend styles */
+  className?: string;
+  /** Whether the link is disabled */
+  disabled?: boolean;
+}

--- a/src/components/atoms/SearchInput/SearchInput.stories.tsx
+++ b/src/components/atoms/SearchInput/SearchInput.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { SearchInput } from "./SearchInput";
+import { Search } from "react-feather";
+
+const meta: Meta<typeof SearchInput> = {
+  title: "Atoms/SearchInput",
+  component: SearchInput,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof SearchInput>;
+
+export const WithIcon: Story = {
+  args: {
+    placeholder: "Search something...",
+    icon: Search,
+  },
+};
+
+export const WithoutIcon: Story = {
+  args: {
+    placeholder: "No icon provided",
+  },
+};
+
+export const CustomStyle: Story = {
+  args: {
+    placeholder: "Styled search input",
+    icon: Search,
+    className: "mt-4 mb-4",
+  },
+};

--- a/src/components/atoms/SearchInput/SearchInput.tsx
+++ b/src/components/atoms/SearchInput/SearchInput.tsx
@@ -1,0 +1,29 @@
+import { combineClassNames } from "../../../utils/combineClassNames";
+import { Icon } from "../Icon";
+import { SearchInputProps } from "./types";
+
+export const SearchInput: React.FC<SearchInputProps> = ({
+  placeholder = "Search",
+  icon,
+  className,
+  ...props
+}) => {
+  return (
+    <div className={combineClassNames("relative w-full max-w-md", className)}>
+      <input
+        type="text"
+        placeholder={placeholder}
+        className={combineClassNames(
+          "w-full rounded-full px-4 py-2 text-body text-dark placeholder-muted border border-gray-mid focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-muted focus-visible:ring-offset-1 transition",
+          icon ? "pr-10" : ""
+        )}
+        {...props}
+      />
+      {icon && (
+        <div className="absolute right-3 top-1/2 -translate-y-1/2 text-muted pointer-events-none">
+          <Icon icon={icon} size={16} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/atoms/SearchInput/__tests__/SearchInput.test.tsx
+++ b/src/components/atoms/SearchInput/__tests__/SearchInput.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { SearchInput } from "../SearchInput";
+import { Search } from "react-feather";
+
+describe("SearchInput", () => {
+  it("renders with default placeholder", () => {
+    render(<SearchInput />);
+    const input = screen.getByPlaceholderText("Search");
+    expect(input).toBeInTheDocument();
+  });
+
+  it("renders with custom placeholder", () => {
+    render(<SearchInput placeholder="Find something..." />);
+    const input = screen.getByPlaceholderText("Find something...");
+    expect(input).toBeInTheDocument();
+  });
+
+  it("applies custom className to wrapper div", () => {
+    render(<SearchInput className="custom-class" />);
+    const wrapper = screen.getByRole("textbox").parentElement;
+    expect(wrapper).toHaveClass("custom-class");
+  });
+
+  it("does not render icon when not passed", () => {
+    render(<SearchInput />);
+    const icon = screen.queryByTestId("search-icon");
+    expect(icon).not.toBeInTheDocument();
+  });
+
+  it("adds padding-right when icon is present", () => {
+    render(<SearchInput icon={Search} />);
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveClass("pr-10");
+  });
+
+  it("does not add padding-right when icon is not present", () => {
+    render(<SearchInput />);
+    const input = screen.getByRole("textbox");
+    expect(input).not.toHaveClass("pr-10");
+  });
+
+  it("passes additional props to input", () => {
+    render(<SearchInput aria-label="custom" />);
+    const input = screen.getByLabelText("custom");
+    expect(input).toBeInTheDocument();
+  });
+});

--- a/src/components/atoms/SearchInput/types.ts
+++ b/src/components/atoms/SearchInput/types.ts
@@ -1,0 +1,9 @@
+import React from "react";
+import { Icon } from "../Icon/types";
+
+export interface SearchInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  placeholder?: string;
+  icon?: Icon;
+  className?: string;
+}

--- a/src/components/atoms/Select/Select.stories.tsx
+++ b/src/components/atoms/Select/Select.stories.tsx
@@ -1,0 +1,49 @@
+import { Select } from "./Select";
+import { SelectOption } from "./types";
+import {
+  Hexagon,
+  Scissors,
+  Check,
+  Star,
+  Type,
+  ChevronDown,
+} from "react-feather";
+import { Meta, StoryObj } from "@storybook/react";
+
+const options: SelectOption[] = [
+  { label: "Native", icon: <Hexagon size={16} />, value: "native" },
+  { label: "Customization", icon: <Scissors size={16} />, value: "custom" },
+  { label: "Checkmark", icon: <Check size={16} />, value: "checkmark" },
+  { label: "Chip", icon: <Star size={16} />, value: "chip" },
+  { label: "Placeholder", icon: <Type size={16} />, value: "placeholder" },
+];
+
+const meta: Meta<typeof Select> = {
+  title: "Atoms/Select",
+  parameters: {
+    layout: "centered",
+  },
+  component: Select,
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Select>;
+
+export const Default: Story = {
+  args: {
+    options,
+    placeholder: "Select",
+    icon: ChevronDown,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    options,
+    disabled: true,
+    placeholder: "Disabled",
+    icon: ChevronDown,
+  },
+};

--- a/src/components/atoms/Select/Select.tsx
+++ b/src/components/atoms/Select/Select.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from "react";
+import { combineClassNames } from "../../../utils/combineClassNames";
+import { SelectProps, SelectOption } from "./types";
+import { Icon } from "../Icon";
+
+export const Select: React.FC<SelectProps> = ({
+  options,
+  placeholder = "Select",
+  onChange,
+  disabled = false,
+  className = "",
+  icon,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState<SelectOption | null>(null);
+
+  const toggleOpen = () => {
+    if (!disabled) setIsOpen((prev) => !prev);
+  };
+
+  const handleSelect = (option: SelectOption) => {
+    setSelected(option);
+    onChange?.(option.value);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className={combineClassNames("relative inline-block w-48", className)}>
+      <button
+        type="button"
+        onClick={toggleOpen}
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        className={combineClassNames(
+          "w-full rounded-full bg-white border text-left flex items-center justify-between px-4 py-2 transition-colors duration-200",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-muted focus-visible:ring-offset-2",
+          disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
+        )}
+      >
+        <span>{selected?.label || placeholder}</span>
+        {icon && <Icon icon={icon} size={16} />}
+      </button>
+
+      {isOpen && (
+        <ul
+          className="absolute z-10 w-full mt-2 rounded-[18px] bg-white shadow focus-visible:outline-none"
+          role="listbox"
+        >
+          {options.map((option) => (
+            <li
+              key={option.value}
+              role="option"
+              onClick={() => handleSelect(option)}
+              className="flex items-center gap-2 px-4 py-2 hover:bg-gray-lighter cursor-pointer"
+            >
+              {option.icon}
+              {option.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/src/components/atoms/Select/__tests__/Select.test.tsx
+++ b/src/components/atoms/Select/__tests__/Select.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Select } from "../Select";
+import { SelectOption } from "../types";
+import { Hexagon } from "react-feather";
+
+const options: SelectOption[] = [
+  { label: "Option 1", value: "1" },
+  { label: "Option 2", value: "2", icon: <Hexagon data-testid="icon-2" /> },
+];
+
+describe("Select", () => {
+  it("renders with default placeholder", () => {
+    render(<Select options={options} />);
+    expect(screen.getByText("Select")).toBeInTheDocument();
+  });
+
+  it("renders with custom placeholder", () => {
+    render(<Select options={options} placeholder="Choose an option" />);
+    expect(screen.getByText("Choose an option")).toBeInTheDocument();
+  });
+
+  it("opens and displays options when clicked", () => {
+    render(<Select options={options} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(screen.getByText("Option 1")).toBeInTheDocument();
+    expect(screen.getByText("Option 2")).toBeInTheDocument();
+  });
+
+  it("selects an option and closes the list", () => {
+    const handleChange = jest.fn();
+    render(<Select options={options} onChange={handleChange} />);
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(screen.getByText("Option 2"));
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(screen.getByText("Option 2")).toBeInTheDocument();
+    expect(handleChange).toHaveBeenCalledWith("2");
+  });
+
+  it("does not open when disabled", () => {
+    render(<Select options={options} disabled />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("renders icons when provided", () => {
+    render(<Select options={options} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByTestId("icon-2")).toBeInTheDocument();
+  });
+
+  it("has correct accessibility attributes", () => {
+    render(<Select options={options} />);
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("aria-haspopup", "listbox");
+    fireEvent.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(screen.getByText("Option 1"));
+    expect(button).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/src/components/atoms/Select/types.ts
+++ b/src/components/atoms/Select/types.ts
@@ -1,0 +1,16 @@
+import { Icon } from "../Icon/types";
+
+export type SelectOption = {
+  label: string;
+  icon?: React.ReactNode;
+  value: string;
+};
+
+export type SelectProps = {
+  options: SelectOption[];
+  placeholder?: string;
+  onChange?: (value: string) => void;
+  disabled?: boolean;
+  className?: string;
+  icon?: Icon;
+};

--- a/src/components/atoms/TextArea/TextArea.stories.tsx
+++ b/src/components/atoms/TextArea/TextArea.stories.tsx
@@ -1,0 +1,458 @@
+// components/atoms/TextArea.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { TextArea } from "./TextArea";
+import { Button } from "../Button";
+
+const meta = {
+  title: "Atoms/TextArea",
+  component: TextArea,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "A clean and simple textarea component with essential functionality for text input.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    placeholder: {
+      control: "text",
+      description: "Placeholder text displayed when the textarea is empty",
+    },
+    rows: {
+      control: { type: "number", min: 1, max: 20 },
+      description: "Number of visible text lines",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Whether the TextArea is disabled",
+    },
+    resize: {
+      control: "select",
+      options: ["none", "vertical", "horizontal", "both"],
+      description: "Whether to allow resizing",
+    },
+    required: {
+      control: "boolean",
+      description: "Whether the field is required",
+    },
+    maxLength: {
+      control: { type: "number", min: 0, max: 1000 },
+      description: "Character count limit",
+    },
+    showCharacterCount: {
+      control: "boolean",
+      description: "Whether to show character count",
+    },
+    className: {
+      control: "text",
+      description: "Custom className to extend styles",
+    },
+    value: {
+      control: "text",
+      description: "Current value of the textarea",
+    },
+  },
+  args: {
+    placeholder: "Enter your text...",
+    rows: 6,
+    disabled: false,
+    resize: "none",
+    required: false,
+    showCharacterCount: false,
+  },
+} satisfies Meta<typeof TextArea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Basic Stories
+export const Default: Story = {
+  args: {
+    placeholder: "Enter your text here...",
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    placeholder: "Enter your text...",
+    value: "This is some sample text content in the textarea.",
+  },
+};
+
+export const Required: Story = {
+  args: {
+    placeholder: "This field is required...",
+    required: true,
+  },
+};
+
+export const CustomRows: Story = {
+  args: {
+    placeholder: "This textarea has 3 rows...",
+    rows: 3,
+  },
+};
+
+export const LargeTextArea: Story = {
+  args: {
+    placeholder: "This is a larger textarea...",
+    rows: 10,
+  },
+};
+
+// State Stories
+export const Disabled: Story = {
+  args: {
+    placeholder: "This field is disabled...",
+    disabled: true,
+    value: "This content cannot be edited",
+  },
+};
+
+// Resize Options
+export const ResizeVertical: Story = {
+  args: {
+    placeholder: "You can resize this vertically...",
+    resize: "vertical",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Drag the bottom-right corner to resize vertically",
+      },
+    },
+  },
+};
+
+export const ResizeHorizontal: Story = {
+  args: {
+    placeholder: "You can resize this horizontally...",
+    resize: "horizontal",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Drag the bottom-right corner to resize horizontally",
+      },
+    },
+  },
+};
+
+export const ResizeBoth: Story = {
+  args: {
+    placeholder: "You can resize this in both directions...",
+    resize: "both",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Drag the bottom-right corner to resize in any direction",
+      },
+    },
+  },
+};
+
+// Character Count Stories
+export const WithCharacterCount: Story = {
+  args: {
+    placeholder: "Tell us about yourself...",
+    maxLength: 200,
+    showCharacterCount: true,
+  },
+};
+
+export const CharacterCountWithContent: Story = {
+  args: {
+    placeholder: "Type something...",
+    maxLength: 100,
+    showCharacterCount: true,
+    value: "This is sample text to show the character counter.",
+  },
+};
+
+export const CharacterLimitReached: Story = {
+  args: {
+    placeholder: "Brief description...",
+    maxLength: 50,
+    showCharacterCount: true,
+    value: "This is a sample text that is exactly fifty ch",
+  },
+};
+
+// Interactive Stories
+export const InteractivePlayground: Story = {
+  args: {
+    placeholder: "Try different configurations...",
+    resize: "none",
+    showCharacterCount: false,
+    maxLength: 500,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Use the controls panel to experiment with different props.",
+      },
+    },
+  },
+};
+
+// Controlled Component Example
+export const ControlledExample: Story = {
+  render: () => {
+    const [value, setValue] = useState("");
+
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setValue(e.target.value);
+    };
+
+    return (
+      <div className="space-y-4">
+        <TextArea
+          placeholder="Type something here..."
+          value={value}
+          onChange={handleChange}
+          showCharacterCount
+          maxLength={100}
+        />
+        <p className="text-sm text-gray-600">Current value: "{value}"</p>
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Example of a controlled TextArea component.",
+      },
+    },
+  },
+};
+
+// Form Integration Example
+export const FormExample: Story = {
+  render: () => (
+    <form className="space-y-4" onSubmit={(e) => e.preventDefault()}>
+      <div>
+        <label
+          htmlFor="subject"
+          className="block text-sm font-medium text-gray-700 mb-2"
+        >
+          Subject *
+        </label>
+        <TextArea
+          id="subject"
+          placeholder="Enter the subject..."
+          required
+          rows={2}
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="message"
+          className="block text-sm font-medium text-gray-700 mb-2"
+        >
+          Message *
+        </label>
+        <TextArea
+          id="message"
+          placeholder="Enter your message..."
+          required
+          maxLength={500}
+          showCharacterCount
+          resize="vertical"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="notes"
+          className="block text-sm font-medium text-gray-700 mb-2"
+        >
+          Additional Notes
+        </label>
+        <TextArea
+          id="notes"
+          placeholder="Any additional information..."
+          rows={3}
+        />
+      </div>
+
+      <Button type="submit" variant="primary">
+        Submit
+      </Button>
+    </form>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Example of TextArea components used in a form context with labels.",
+      },
+    },
+  },
+};
+
+// Custom Styling Example
+export const CustomStyling: Story = {
+  args: {
+    placeholder: "Custom styled textarea...",
+    className:
+      "border-2 border-blue-300 focus-visible:border-blue-500 focus-visible:ring-blue-500",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Example with custom styling using the className prop.",
+      },
+    },
+  },
+};
+
+// Different Use Cases
+export const CommentBox: Story = {
+  args: {
+    placeholder: "Write your comment here...",
+    rows: 4,
+    maxLength: 280,
+    showCharacterCount: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Configured as a comment box with character limit.",
+      },
+    },
+  },
+};
+
+export const FeedbackForm: Story = {
+  args: {
+    placeholder: "Please share your feedback...",
+    rows: 8,
+    resize: "vertical",
+    required: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Configured as a feedback form with vertical resize.",
+      },
+    },
+  },
+};
+
+export const CodeEditor: Story = {
+  args: {
+    placeholder: "Enter your code here...",
+    rows: 12,
+    resize: "both",
+    className: "font-mono text-sm",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Configured for code input with monospace font.",
+      },
+    },
+  },
+};
+
+// Resize Showcase
+export const ResizeShowcase: Story = {
+  render: () => (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div>
+        <h3 className="text-sm font-medium text-gray-700 mb-2">No Resize</h3>
+        <TextArea placeholder="Cannot be resized..." resize="none" rows={4} />
+      </div>
+
+      <div>
+        <h3 className="text-sm font-medium text-gray-700 mb-2">
+          Vertical Resize
+        </h3>
+        <TextArea
+          placeholder="Can be resized vertically..."
+          resize="vertical"
+          rows={4}
+        />
+      </div>
+
+      <div>
+        <h3 className="text-sm font-medium text-gray-700 mb-2">
+          Horizontal Resize
+        </h3>
+        <TextArea
+          placeholder="Can be resized horizontally..."
+          resize="horizontal"
+          rows={4}
+        />
+      </div>
+
+      <div>
+        <h3 className="text-sm font-medium text-gray-700 mb-2">
+          Both Directions
+        </h3>
+        <TextArea
+          placeholder="Can be resized in both directions..."
+          resize="both"
+          rows={4}
+        />
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "All resize options displayed together for comparison.",
+      },
+    },
+  },
+};
+
+// Character Count Showcase
+export const CharacterCountShowcase: Story = {
+  render: () => (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-sm font-medium text-gray-700 mb-2">
+          Without Character Count
+        </h3>
+        <TextArea placeholder="No character limit..." maxLength={100} />
+      </div>
+
+      <div>
+        <h3 className="text-sm font-medium text-gray-700 mb-2">
+          With Character Count
+        </h3>
+        <TextArea
+          placeholder="Shows character count..."
+          maxLength={100}
+          showCharacterCount
+        />
+      </div>
+
+      <div>
+        <h3 className="text-sm font-medium text-gray-700 mb-2">
+          Character Count with Content
+        </h3>
+        <TextArea
+          placeholder="Pre-filled content..."
+          maxLength={150}
+          showCharacterCount
+          value="This textarea has some pre-filled content to demonstrate the character counter."
+        />
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Different character count configurations.",
+      },
+    },
+  },
+};

--- a/src/components/atoms/TextArea/TextArea.tsx
+++ b/src/components/atoms/TextArea/TextArea.tsx
@@ -1,0 +1,82 @@
+// components/atoms/TextArea.tsx
+import { forwardRef } from "react";
+import { TextAreaProps } from "./types";
+import { combineClassNames } from "../../../utils/combineClassNames";
+
+// Default styling based on your original component
+const defaultClasses = "p-6 text-body rounded-2xl";
+
+const resizeClasses = {
+  none: "resize-none",
+  vertical: "resize-y",
+  horizontal: "resize-x",
+  both: "resize",
+};
+
+export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  (
+    {
+      placeholder = "Enter your text...",
+      rows = 6,
+      disabled = false,
+      resize = "none",
+      required = false,
+      className = "",
+      maxLength,
+      showCharacterCount = false,
+      value,
+      onChange,
+      ...props
+    },
+    ref
+  ) => {
+    const currentLength = typeof value === "string" ? value.length : 0;
+    const showCounter = showCharacterCount && maxLength;
+
+    const baseClasses = [
+      "w-full transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1",
+      "border border-gray-300 bg-white focus-visible:ring-muted",
+      defaultClasses,
+      resizeClasses[resize],
+    ];
+
+    const stateClasses = [
+      disabled && "opacity-50 cursor-not-allowed bg-gray-100",
+      !disabled && "text-gray-900 placeholder-gray-500",
+    ];
+
+    const classes = combineClassNames([
+      ...baseClasses,
+      ...stateClasses,
+      className,
+    ]);
+
+    return (
+      <div className="w-full">
+        <div className="relative">
+          <textarea
+            ref={ref}
+            className={classes}
+            rows={rows}
+            placeholder={placeholder}
+            disabled={disabled}
+            required={required}
+            maxLength={maxLength}
+            value={value}
+            onChange={onChange}
+            {...props}
+          />
+
+          {showCounter && (
+            <div className="absolute bottom-3 right-3 text-xs text-gray-500 bg-white px-2 py-1 rounded">
+              {currentLength}
+              {maxLength && `/${maxLength}`}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+);
+
+TextArea.displayName = "TextArea";

--- a/src/components/atoms/TextArea/__tests__/TextArea.test.tsx
+++ b/src/components/atoms/TextArea/__tests__/TextArea.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TextArea } from "../TextArea";
+
+describe("TextArea", () => {
+  it("renders with default placeholder", () => {
+    render(<TextArea />);
+    expect(
+      screen.getByPlaceholderText("Enter your text...")
+    ).toBeInTheDocument();
+  });
+
+  it("renders with custom placeholder and rows", () => {
+    render(<TextArea placeholder="Your message" rows={10} />);
+    const textarea = screen.getByPlaceholderText("Your message");
+    expect(textarea).toHaveAttribute("rows", "10");
+  });
+
+  it("disables textarea when `disabled` prop is true", () => {
+    render(<TextArea disabled />);
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toBeDisabled();
+  });
+
+  it("calls onChange when value changes", () => {
+    const handleChange = jest.fn();
+    render(<TextArea value="" onChange={handleChange} />);
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Test" },
+    });
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it("applies the correct resize class based on `resize` prop", () => {
+    const { rerender } = render(<TextArea resize="none" />);
+    expect(screen.getByRole("textbox").className).toContain("resize-none");
+
+    rerender(<TextArea resize="vertical" />);
+    expect(screen.getByRole("textbox").className).toContain("resize-y");
+
+    rerender(<TextArea resize="horizontal" />);
+    expect(screen.getByRole("textbox").className).toContain("resize-x");
+
+    rerender(<TextArea resize="both" />);
+    expect(screen.getByRole("textbox").className).toContain("resize");
+  });
+});

--- a/src/components/atoms/TextArea/types.ts
+++ b/src/components/atoms/TextArea/types.ts
@@ -1,0 +1,19 @@
+export interface TextAreaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  /** Placeholder text */
+  placeholder?: string;
+  /** Number of visible text lines */
+  rows?: number;
+  /** Whether the TextArea is disabled */
+  disabled?: boolean;
+  /** Whether to allow resizing */
+  resize?: "none" | "vertical" | "horizontal" | "both";
+  /** Whether the field is required */
+  required?: boolean;
+  /** Custom className to extend styles */
+  className?: string;
+  /** Character count limit */
+  maxLength?: number;
+  /** Whether to show character count */
+  showCharacterCount?: boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,13 @@ import "./index.css";
 
 export { Button } from "./components/atoms/Button";
 
-export type { ButtonProps } from "./components/atoms/Button";
+export type { ButtonProps } from "./components/atoms/Button/types";
 
 export { Icon } from "./components/atoms/Icon";
+export { Link } from "./components/atoms/Link/Link";
+export { SearchInput } from "./components/atoms/SearchInput/SearchInput";
+export { Select } from "./components/atoms/Select/Select";
+export { TextArea } from "./components/atoms/TextArea/TextArea";
 
 // Export tailwind config for users who want to extend it
 // export { default as tailwindConfig } from '../tailwind.config';

--- a/src/utils/__tests__/combineClassNames.test.ts
+++ b/src/utils/__tests__/combineClassNames.test.ts
@@ -1,0 +1,48 @@
+import { combineClassNames } from "../combineClassNames";
+
+describe("combineClassNames", () => {
+  it("joins simple string arguments", () => {
+    expect(combineClassNames("btn", "primary", "active")).toBe(
+      "btn primary active"
+    );
+  });
+
+  it("ignores falsey values (false, null, undefined, 0)", () => {
+    expect(combineClassNames("btn", false, null, undefined, "", 0)).toBe("btn");
+  });
+
+  it("handles numbers", () => {
+    expect(combineClassNames(1, 2, "px")).toBe("1 2 px");
+  });
+
+  it("handles arrays of class names", () => {
+    expect(combineClassNames(["btn", "active"])).toBe("btn active");
+  });
+
+  it("flattens nested arrays", () => {
+    expect(combineClassNames(["btn", ["primary", ["rounded"]]])).toBe(
+      "btn primary rounded"
+    );
+  });
+
+  it("adds class names from objects with truthy values", () => {
+    expect(combineClassNames({ btn: true, hidden: false, active: 1 })).toBe(
+      "btn active"
+    );
+  });
+
+  it("combines strings, objects, and arrays", () => {
+    expect(
+      combineClassNames("btn", { active: true, disabled: false }, [
+        "rounded",
+        { "bg-red": true },
+      ])
+    ).toBe("btn active rounded bg-red");
+  });
+  it("ignores symbol and function types", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(
+      combineClassNames("btn", Symbol("sym") as any, (() => {}) as any)
+    ).toBe("btn");
+  });
+});

--- a/src/utils/combineClassNames.ts
+++ b/src/utils/combineClassNames.ts
@@ -1,0 +1,36 @@
+// utils/combineClassNames.ts
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ClassValue =
+  | string
+  | number
+  | null
+  | boolean
+  | undefined
+  | ClassValue[]
+  | { [key: string]: any };
+
+export function combineClassNames(...args: ClassValue[]): string {
+  const classes: string[] = [];
+
+  for (const arg of args) {
+    if (!arg) continue;
+
+    const type = typeof arg;
+
+    if (type === "string" || type === "number") {
+      classes.push(String(arg));
+    } else if (Array.isArray(arg)) {
+      const inner = combineClassNames(...arg);
+      if (inner) classes.push(inner);
+    } else if (type === "object") {
+      for (const key in arg as object) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if ((arg as Record<string, any>)[key]) {
+          classes.push(key);
+        }
+      }
+    }
+  }
+
+  return classes.join(" ");
+}


### PR DESCRIPTION
## ✅ Summary
This PR adds four new foundational UI components to the design system: TextArea, Select, SearchInput, and Link. Each component is designed with accessibility, reusability, and style consistency in mind. All components come with corresponding unit tests to ensure stability and confidence in future changes.

### 🧩 What’s Included
1. TextArea
    Supports rows, resize, disabled, required, and maxLength.
    Optional character counter via showCharacterCount.
    Rounded UI with consistent padding and focus ring.
    Forward ref support and full keyboard accessibility.
    ✅ Tests added for all core behaviors.

2. Select
    Custom dropdown with keyboard and mouse interactions.
    Supports icon + label options.
    Controlled open/close state.
    Accessible with aria-* attributes.
    Fully styled with Tailwind and combineClassNames.
    ✅ Tests added for rendering, selection, and focus behavior.

3. SearchInput
    Optional icon via props.
    Rounded input with focus-visible ring only on tab (not mouse).
    Input className extensibility supported.
    Built with composability and accessibility.
    ✅ Tests added for conditional icon rendering, input props, and styling.

4. Link
    Supports variant styles (default, secondary).
    Auto-detects external links and applies appropriate rel/target.
    disabled, underline, and custom className support.
    Fully accessible and keyboard navigable.
    ✅ Tests added for variant styles, disabled state, external link detection, and more.

### 🛠 Technical Notes
    All components use Tailwind CSS utility classes.
    Common combineClassNames utility used for dynamic class merging.
    Focus rings respect focus-visible to avoid showing on mouse click.
    Fully typed with TypeScript, with shared prop types in types.ts.


📷 screenshot
![image](https://github.com/user-attachments/assets/413d93b3-d69c-4b75-b916-7bc523640f87)
![image](https://github.com/user-attachments/assets/8cad8bfb-64b8-4b76-b691-0c6809ece782)
![image](https://github.com/user-attachments/assets/ecf03b94-819f-434b-a0e7-2e3bde505a2b)
![image](https://github.com/user-attachments/assets/71877210-32a0-4b74-8887-31f07b8f9df8)
![image](https://github.com/user-attachments/assets/afb612e1-2d67-477a-89e5-018b79f771a6)


